### PR TITLE
Update Groovy version to latest patch to support Java 24

### DIFF
--- a/openapi-annotation-processor/build.gradle.kts
+++ b/openapi-annotation-processor/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(project(":openapi-annotation-processor"))
 
     implementation(kotlin("reflect"))
-    implementation("org.apache.groovy:groovy:4.0.21")
+    implementation("org.apache.groovy:groovy:4.0.27")
 
     implementation("io.javalin:javalin:6.6.0") {
         exclude(group = "org.slf4j")


### PR DESCRIPTION
Groovy patch version 24 supports Java 24, but use the latest Groovy patch version of 27.
See https://github.com/gradle/gradle/issues/32290#issuecomment-2740433685.