### PR TITLE
docs: Replace broken https://github.com/javalin/javalin-openapi/wiki …

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,9 +7,7 @@ the API looks quite the same despite some minor changes.
 
 ### How to use
 
-* [Wiki / Installation](https://github.com/javalin/javalin-openapi/wiki/1.-Installation)
-* [Wiki / Setup](https://github.com/javalin/javalin-openapi/wiki/2.-Setup)
-* [Wiki / Features](https://github.com/javalin/javalin-openapi/wiki/3.-Features)
+See https://javalin.github.io/javalin-openapi.
 
 ### Notes
 * Reflection free


### PR DESCRIPTION
…with https://javalin.github.io/javalin-openapi on README

Updated usage instructions to point to the Javalin OpenAPI documentation website, as the wiki seems to have been disabled, and the existing links are broken.