### PR TITLE
GH-280 Support `x-enum-descriptions` for enums

### DIFF
--- a/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/experimental/processor/generators/TypeSchemaGenerator.kt
+++ b/openapi-annotation-processor/src/main/kotlin/io/javalin/openapi/experimental/processor/generators/TypeSchemaGenerator.kt
@@ -42,6 +42,7 @@ class TypeSchemaGenerator(val context: AnnotationProcessorContext) {
 
                 val namingStrategy = source.getAnnotation(OpenApiNaming::class.java)?.value
                 val values = createArrayNode()
+                val descriptions = createArrayNode()
 
                 source.enclosedElements
                     .filterIsInstance<VariableElement>()
@@ -49,23 +50,32 @@ class TypeSchemaGenerator(val context: AnnotationProcessorContext) {
                     .filter { context.isAssignable(it.asType(), type.mirror) }
                     .map { element ->
                         val customName = element.getAnnotation(OpenApiName::class.java)
-                        when {
+                        val description = element.getAnnotation(OpenApiDescription::class.java)
+                        val name = when {
                             customName != null -> customName.value
                             namingStrategy != null -> translatePropertyName(namingStrategy, element.toSimpleName())
                             else -> element.toSimpleName()
                         }
+
+                        Pair(name, description?.value ?: "")
                     }
-                    .forEach { name ->
+                    .forEach { (name, description) ->
                         if (enumType != null && enumType.type != "string") {
                             values.add(jsonMapper.readTree(name))
                         } else {
                             values.add(name)
                         }
+
+                        descriptions.add(description)
                     }
 
                 schema.put("type", enumType?.type ?: "string")
                 enumType?.format?.also { schema.put("format", it) }
                 schema.set<JsonNode>("enum", values)
+
+                if (descriptions.find({ description -> description.isTextual && description.asText().isNotEmpty()}) != null) {
+                    schema.set<JsonNode>("x-enum-descriptions", descriptions)
+                }
 
                 val extra = source.findExtra(context)
                 schema.addExtra(extra)

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
@@ -418,6 +418,39 @@ internal class TypeMappersTest : OpenApiAnnotationProcessorSpecification() {
             ))
     }
 
+    private enum class xEnumDescriptionsEnum {
+        @OpenApiName("1")
+        @OpenApiDescription("Description of 1")
+        REQUEST_TYPE_1,
+        @OpenApiName("2")
+        @OpenApiDescription("Description of 2")
+        REQUEST_TYPE_2
+    }
+
+    @OpenApi(
+        path = "x-enum-descriptions-enum",
+        versions = ["should_support_x_enum_descriptions_enum"],
+        responses = [OpenApiResponse(status = "200", content = [OpenApiContent(from = xEnumDescriptionsEnum::class)])]
+    )
+    @Test
+    fun should_support_x_enum_descriptions_enum() = withOpenApi("should_support_x_enum_descriptions_enum") {
+        println(it)
+
+        assertThatJson(it)
+            .inPath("$.components.schemas.xEnumDescriptionsEnum")
+            .isObject
+            .isEqualTo(json(
+                // language=json
+                """
+                {
+                  "type": "string",
+                  "enum": ["1", "2"],
+                  "x-enum-descriptions": ["Description of 1", "Description of 2"]
+                }
+                """
+            ))
+    }
+
     @OpenApiDescription("A regular string enum with description")
     private enum class DescribedStringEnum {
         ALPHA,

--- a/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
+++ b/openapi-annotation-processor/src/test/kotlin/io/javalin/openapi/processor/TypeMappersTest.kt
@@ -418,7 +418,7 @@ internal class TypeMappersTest : OpenApiAnnotationProcessorSpecification() {
             ))
     }
 
-    private enum class xEnumDescriptionsEnum {
+    private enum class XEnumDescriptionsEnum {
         @OpenApiName("1")
         @OpenApiDescription("Description of 1")
         REQUEST_TYPE_1,
@@ -430,14 +430,14 @@ internal class TypeMappersTest : OpenApiAnnotationProcessorSpecification() {
     @OpenApi(
         path = "x-enum-descriptions-enum",
         versions = ["should_support_x_enum_descriptions_enum"],
-        responses = [OpenApiResponse(status = "200", content = [OpenApiContent(from = xEnumDescriptionsEnum::class)])]
+        responses = [OpenApiResponse(status = "200", content = [OpenApiContent(from = XEnumDescriptionsEnum::class)])]
     )
     @Test
     fun should_support_x_enum_descriptions_enum() = withOpenApi("should_support_x_enum_descriptions_enum") {
         println(it)
 
         assertThatJson(it)
-            .inPath("$.components.schemas.xEnumDescriptionsEnum")
+            .inPath("$.components.schemas.XEnumDescriptionsEnum")
             .isObject
             .isEqualTo(json(
                 // language=json


### PR DESCRIPTION
Implements #280 

Added a test to reflect the changes. Improvements I could think of:
1. Use a different annotation than `OpenApiDescription` for that
2. Introduce an additional annotation (something like `OpenApiEnumDescription("field-name")` which allows to control the name of the `x-enum-descriptions` field (since its a non-standard field), its currently hardcoded but could be dynamic.